### PR TITLE
fix: cosign update bundle flag missing:

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,16 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # main
       - name: Install syft
         uses: anchore/sbom-action/download-syft@aa0e114b2e19480f157109b9922bda359bd98b90 # v0.20.8
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghcli
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/boost
+          docker system prune -af
+          df -h
+          
       - name: Run GoReleaser Snapshot
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         id: run-goreleaser-snapshot

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -174,6 +174,7 @@ signs:
     args:
       - "sign-blob"
       - "--yes"
+      - "--bundle"
       - "--output-signature"
       - "${artifact}-keyless.sig"
       - "--output-certificate"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -188,6 +188,7 @@ signs:
     args:
       - "sign-blob"
       - "--yes"
+      - "--bundle"
       - "--output-signature"
       - "${artifact}-keyless.sig"
       - "--output-certificate"


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the --bundle flag to cosign sign-blob in both Goreleaser configs to generate a Sigstore bundle for each artifact. This fixes missing bundle files in releases and ensures verification works with cosign’s bundle flow.

- **Bug Fixes**
  - Include --bundle in .goreleaser.yaml and .goreleaser-nightly.yaml cosign args.
  - Release workflow frees disk space to prevent runner failures; artifacts include signature, certificate, and bundle for verification.

<sup>Written for commit 47d09c0a0b27a274d0f7359963b81d2c5c87981e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



