### PR TITLE
Fix/release workflow issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -238,7 +238,7 @@ jobs:
           sed -i s/local-organic-guac/ghcr.io\\/${{ github.repository_owner }}\\/guac:${{ github.ref_name }}/ guac-compose/.env
           tar -zcvf guac-compose.tar.gz guac-compose/
           rm -rf guac-compose/
-          gh release upload ${{ github.ref_name }} guac-compose.tar.gz
+          gh release upload ${{ github.ref_name }} guac-compose.tar.gz --clobber
           rm guac-compose.tar.gz
         shell: bash
       - name: Modify and publish demo compose yaml
@@ -249,7 +249,7 @@ jobs:
           set -euo pipefail
           cp container_files/guac-demo-compose.yaml .
           sed -i s/\$GUAC_IMAGE/ghcr.io\\/${{ github.repository_owner }}\\/guac:${{ github.ref_name }}/ guac-demo-compose.yaml
-          gh release upload ${{ github.ref_name }} guac-demo-compose.yaml
+          gh release upload ${{ github.ref_name }} guac-demo-compose.yaml --clobber
           rm guac-demo-compose.yaml
         shell: bash
       - name: Modify and publish postgres compose yaml
@@ -260,6 +260,6 @@ jobs:
           set -euo pipefail
           cp container_files/guac-postgres-compose.yaml .
           sed -i s/\$GUAC_IMAGE/ghcr.io\\/${{ github.repository_owner }}\\/guac:${{ github.ref_name }}/ guac-postgres-compose.yaml
-          gh release upload ${{ github.ref_name }} guac-postgres-compose.yaml
+          gh release upload ${{ github.ref_name }} guac-postgres-compose.yaml --clobber
           rm guac-postgres-compose.yaml
         shell: bash

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -211,7 +211,7 @@ changelog:
 
 release:
   prerelease: auto
-  draft: true
+  draft: false
   replace_existing_draft: true
 # The lines beneath this are called `modelines`. See `:help modeline`
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow so new releases are published (non-draft) and visible to users and automation.

- **Bug Fixes**
  - Set GoReleaser to create non-draft releases.
  - Use --clobber when uploading assets so re-runs overwrite files under the tag.

<sup>Written for commit 3186f3e471b94302be64c980569b2840ad78ca2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

