### PR TITLE
fix: handle empty source_names gracefully in scorecard

### DIFF
--- a/pkg/certifier/components/source/source.go
+++ b/pkg/certifier/components/source/source.go
@@ -58,6 +58,12 @@ func (s sourceQuery) GetComponents(ctx context.Context, compChan chan<- interfac
 		if err != nil {
 			return fmt.Errorf("failed to query packages with error: %w", err)
 		}
+
+		// handle nil response or empty SourcesList when table is empty
+		if srcConn == nil || srcConn.SourcesList == nil {
+			break
+		}
+
 		srcEdges := srcConn.SourcesList.Edges
 
 		for _, srcNode := range srcEdges {


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a panic in scorecard when the source_names table is empty. GetComponents now exits early if the source query returns nil or an empty SourcesList.

<sup>Written for commit 452562c8e6f13bba2c18c6b024d36331a329ba79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

