### PR TITLE
Feat/add custom scorecard certifer new

### DIFF
--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -24,6 +24,7 @@ import (
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/components/source"
 	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/logging"
 	"github.com/ossf/scorecard/v4/docs/checks"
 	"github.com/ossf/scorecard/v4/log"
 
@@ -39,7 +40,7 @@ type scorecard struct {
 var ErrArtifactNodeTypeMismatch = fmt.Errorf("rootComponent type is not *source.SourceNode")
 
 // CertifyComponent is a certifier that generates scorecard attestations
-func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
+func (s scorecard) CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
 	if docChannel == nil {
 		return fmt.Errorf("docChannel cannot be nil")
 	}
@@ -110,7 +111,10 @@ func NewScorecardCertifier(sc Scorecard) (certifier.Certifier, error) {
 	// check if the GITHUB_AUTH_TOKEN is set
 	s, ok := os.LookupEnv("GITHUB_AUTH_TOKEN")
 	if !ok || s == "" {
-		return nil, fmt.Errorf("GITHUB_AUTH_TOKEN is not set")
+		// Log warning but allow initialization without token
+		// The API path will still work, only local computation will fail
+		logger := logging.FromContext(context.Background())
+		logger.Warnf("GITHUB_AUTH_TOKEN not set - scorecard API will work, but local computation fallback will be disabled")
 	}
 
 	return &scorecard{

--- a/pkg/certifier/scorecard/scorecardRunner.go
+++ b/pkg/certifier/scorecard/scorecardRunner.go
@@ -18,19 +18,147 @@ package scorecard
 import (
 	"context"
 	"fmt"
-
+	"github.com/guacsec/guac/pkg/logging"
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/checks"
 	"github.com/ossf/scorecard/v4/log"
 	sc "github.com/ossf/scorecard/v4/pkg"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
 )
+
+const githubPrefix = "github.com/"
 
 // scorecardRunner is a struct that implements the Scorecard interface.
 type scorecardRunner struct {
 	ctx context.Context
 }
 
+// normalizeRepoName ensures the repo name has the github.com/ prefix required by the Scorecard API.
+// If the prefix is missing, it is added. If the repo name already has the prefix, it is returned as-is.
+func normalizeRepoName(repoName string) string {
+	if strings.HasPrefix(repoName, githubPrefix) {
+		return repoName
+	}
+	return githubPrefix + repoName
+}
+
 func (s scorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.ScorecardResult, error) {
+	logger := logging.FromContext(s.ctx)
+	repoName = normalizeRepoName(repoName)
+
+	// First try API approach
+	logger.Debugf("Attempting to fetch scorecard from API for repo: %s, commit: %s", repoName, commitSHA)
+	result, err := s.getScoreFromAPI(repoName, commitSHA, tag)
+	if err == nil {
+		logger.Infof("Successfully fetched scorecard from API for repo: %s", repoName)
+		return result, nil
+	}
+
+	// Log API failure and check if we can fallback to local computation
+	logger.Warnf("API fetch failed for repo %s: %v", repoName, err)
+
+	// Check if GitHub token is available for local computation
+	if _, ok := os.LookupEnv("GITHUB_AUTH_TOKEN"); !ok {
+		logger.Errorf("Cannot fall back to local computation - GITHUB_AUTH_TOKEN not set")
+		return nil, fmt.Errorf("scorecard API failed and GITHUB_AUTH_TOKEN not available for local computation: %w", err)
+	}
+
+	logger.Infof("Falling back to local computation for repo: %s", repoName)
+	result, err = s.computeScore(repoName, commitSHA, tag)
+	if err != nil {
+		logger.Errorf("Failed to compute scorecard locally for repo %s: %v", repoName, err)
+	}
+	return result, err
+}
+
+func (s scorecardRunner) getScoreFromAPI(repoName, commitSHA, tag string) (*sc.ScorecardResult, error) {
+	logger := logging.FromContext(s.ctx)
+
+	// If tag is provided without a valid commitSHA, skip API and use local computation
+	// The API cannot resolve tags, but computeScore can look up the commit for a tag
+	if (commitSHA == "" || commitSHA == "HEAD") && tag != "" {
+		logger.Debugf("Tag %s provided without commit SHA - skipping API, will use local computation", tag)
+		return nil, fmt.Errorf("tag provided without commit SHA; falling back to local computation for tag %s", tag)
+	}
+
+	baseURL, err := url.JoinPath("https://api.securityscorecards.dev", "projects", repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	// If commitSHA is provided, try with it first
+	if commitSHA != "" && commitSHA != "HEAD" {
+		urlWithCommit := baseURL + "?commit=" + commitSHA
+		result, err := s.fetchFromAPI(urlWithCommit)
+		if err == nil {
+			return result, nil
+		}
+		logger.Debugf("API call with commit %s failed, retrying without commit: %v", commitSHA, err)
+	}
+
+	result, err := s.fetchFromAPI(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s scorecardRunner) fetchFromAPI(apiURL string) (*sc.ScorecardResult, error) {
+	logger := logging.FromContext(s.ctx)
+	logger.Debugf("Making API request to: %s", apiURL)
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "guac-scorecard-certifier/1.0")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scorecard request failed: %w", err)
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	logger.Debugf("API response status code: %d", resp.StatusCode)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("scorecard not found in API")
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Use scorecard's built-in JSON parser, which is experimental
+	// but still better then rolling out your own type
+	result, _, err := sc.ExperimentalFromJSON2(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode API response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (s scorecardRunner) computeScore(repoName, commitSHA, tag string) (*sc.ScorecardResult, error) {
+	logger := logging.FromContext(s.ctx)
+	logger.Infof("Starting local scorecard computation for repo: %s, commit: %s, tag: %s", repoName, commitSHA, tag)
+
 	// Can't use guacs standard logger because scorecard uses a different logger.
 	defaultLogger := log.NewLogger(log.DefaultLevel)
 	repo, repoClient, ossFuzzClient, ciiClient, vulnsClient, err := checker.GetClients(s.ctx, repoName, "", defaultLogger)
@@ -79,10 +207,12 @@ func (s scorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.Scorecar
 		}
 	}
 
+	logger.Debugf("Running %d scorecard checks locally", len(enabledChecks))
 	res, err := sc.RunScorecard(s.ctx, repo, commitSHA, 0, enabledChecks, repoClient, ossFuzzClient, ciiClient, vulnsClient)
 	if err != nil {
 		return nil, fmt.Errorf("error, failed to run scorecard: %w", err)
 	}
+
 	if res.Repo.Name == "" {
 		// The commit SHA can be invalid or the repo can be private.
 		return nil, fmt.Errorf("error, failed to get scorecard data for repo %v, commit SHA %v", res.Repo.Name, commitSHA)

--- a/pkg/certifier/scorecard/scorecard_test.go
+++ b/pkg/certifier/scorecard/scorecard_test.go
@@ -61,7 +61,8 @@ func TestNewScorecard(t *testing.T) {
 			sc:            mockScorecard{},
 			authToken:     "",
 			wantAuthToken: true,
-			wantErr:       true,
+			wantErr:       false,
+			want:          &scorecard{scorecard: mockScorecard{}, ghToken: ""},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a custom Scorecard certifier that fetches results from the public API with smart retry and falls back to local computation when needed. This improves reliability and removes the hard dependency on GITHUB_AUTH_TOKEN.

- **New Features**
  - API-first retrieval with commit-aware retry (404 with commit → retry without commit).
  - Local fallback when the API fails and a GitHub token is available.
  - Tag handling: if tag is provided without a commit (or commit is HEAD), skip API and compute locally.
  - Repo name normalization to ensure the github.com/ prefix.
  - Initialization works without GITHUB_AUTH_TOKEN; logs a warning and disables local fallback.

<sup>Written for commit 15c5e848534978e8804616338df5de8ccc58eff7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

