### PR TITLE
fix: changes to make non-draft releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,11 +60,8 @@ jobs:
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghcli
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/local/share/boost
-          docker system prune -af
-          df -h
       - name: Run GoReleaser Snapshot
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         id: run-goreleaser-snapshot
@@ -192,7 +189,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # must use semver here
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
-      upload-assets: false
+      upload-assets: true
 
   provenance-container:
     name: generate provenance for container

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -211,7 +211,7 @@ changelog:
 
 release:
   prerelease: auto
-  draft: true
+  draft: false
   replace_existing_draft: true
 # The lines beneath this are called `modelines`. See `:help modeline`
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish non-draft releases by default and upload provenance assets to the GitHub release. Also simplifies runner cleanup to avoid unnecessary pruning.

- **Refactors**
  - GoReleaser: set release.draft to false to publish releases.
  - SLSA generator: set upload-assets to true to attach provenance assets.
  - Removed extra disk cleanup steps (ghcli removal, docker prune, df -h).

<sup>Written for commit d6ea50f027d7522f363a2865d4911bd1fc259cfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

