### PR TITLE
feat: label support for guaccollect

### DIFF
--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -133,7 +133,7 @@ you have access to read and write to the respective blob store.`,
 			}()
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue, nil)
 	},
 }
 

--- a/cmd/guaccollect/cmd/files.go
+++ b/cmd/guaccollect/cmd/files.go
@@ -46,6 +46,8 @@ type filesOptions struct {
 	poll bool
 	// enable/disable message publish to queue
 	publishToQueue bool
+	// labels to attach to collected documents as HasMetadata
+	labels map[string]string
 }
 
 var filesCmd = &cobra.Command{
@@ -54,11 +56,11 @@ var filesCmd = &cobra.Command{
 	Long: `
 guaccollect files takes in a file path to ingest all documents that are found
 via the GUAC files collector. Ingestion to GUAC happens via an event stream (NATS)
-to allow for decoupling of the collectors from the ingestion into GUAC. 
+to allow for decoupling of the collectors from the ingestion into GUAC.
 
 Each collector collects the "document" and stores it in the blob store for further
-evaluation. The collector creates a CDEvent (https://cdevents.dev/) that is published via 
-the event stream. The downstream guacingest subscribes to the stream and retrieves the "document" from the blob store for 
+evaluation. The collector creates a CDEvent (https://cdevents.dev/) that is published via
+the event stream. The downstream guacingest subscribes to the stream and retrieves the "document" from the blob store for
 processing and ingestion.
 
 Various blob stores can be used (such as S3, Azure Blob, Google Cloud Bucket) as documented here: https://gocloud.dev/howto/blob/
@@ -73,6 +75,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetString("blob-addr"),
 			viper.GetBool("service-poll"),
 			viper.GetBool("publish-to-queue"),
+			viper.GetStringSlice("label"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -90,11 +93,11 @@ you have access to read and write to the respective blob store.`,
 			logger.Fatalf("unable to register file collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue, opts.labels)
 	},
 }
 
-func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, pubToQueue bool, args []string) (filesOptions, error) {
+func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, pubToQueue bool, labelArgs []string, args []string) (filesOptions, error) {
 	var opts filesOptions
 
 	opts.pubsubAddr = pubsubAddr
@@ -108,7 +111,28 @@ func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, pubToQueue bool,
 
 	opts.path = args[0]
 
+	labels, err := parseLabels(labelArgs)
+	if err != nil {
+		return opts, err
+	}
+	opts.labels = labels
+
 	return opts, nil
+}
+
+func parseLabels(labelArgs []string) (map[string]string, error) {
+	if len(labelArgs) == 0 {
+		return nil, nil
+	}
+	labels := make(map[string]string, len(labelArgs))
+	for _, l := range labelArgs {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid label format %q, expected key=value", l)
+		}
+		labels[parts[0]] = parts[1]
+	}
+	return labels, nil
 }
 
 func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub, publishToQueue bool) (func(*processor.Document) error, error) {
@@ -117,7 +141,7 @@ func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub 
 	}, nil
 }
 
-func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr string, publishToQueue bool) {
+func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr string, publishToQueue bool, labels map[string]string) {
 	logger := logging.FromContext(ctx)
 
 	// initialize blob store
@@ -150,6 +174,9 @@ func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr
 
 	// Set emit function to go through the entire pipeline
 	emit := func(d *processor.Document) error {
+		if len(labels) > 0 {
+			d.Labels = labels
+		}
 		err = collectorPubFunc(d)
 		// updating the logger to the child logger so that if there is an error we which document has it
 		logger = d.ChildLogger

--- a/cmd/guaccollect/cmd/gcs.go
+++ b/cmd/guaccollect/cmd/gcs.go
@@ -87,7 +87,11 @@ var gcsCmd = &cobra.Command{
 			defer csubClient.Close()
 		}
 
-		initializeNATsandCollector(ctx, opts.pubSubAddr, opts.blobAddr, opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, opts.pubSubAddr, opts.blobAddr, opts.publishToQueue, labels)
 	},
 }
 

--- a/cmd/guaccollect/cmd/github.go
+++ b/cmd/guaccollect/cmd/github.go
@@ -169,7 +169,11 @@ you have access to read and write to the respective blob store.`,
 			logger.Fatalf("unable to register Github collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue, labels)
 	},
 }
 

--- a/cmd/guaccollect/cmd/kubescape.go
+++ b/cmd/guaccollect/cmd/kubescape.go
@@ -80,7 +80,11 @@ $ guaccollect kubescape --service-poll=false --kubescape-filtered --kubescape-na
 			defer csubClient.Close()
 		}
 
-		initializeNATsandCollector(ctx, opts.pubSubAddr, opts.blobAddr, opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, opts.pubSubAddr, opts.blobAddr, opts.publishToQueue, labels)
 	},
 }
 

--- a/cmd/guaccollect/cmd/label_test.go
+++ b/cmd/guaccollect/cmd/label_test.go
@@ -1,0 +1,103 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestParseLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		wantLen   int
+		wantKey   string
+		wantValue string
+		wantErr   bool
+	}{
+		{
+			name:    "empty input",
+			input:   []string{},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:      "single label",
+			input:     []string{"env=production"},
+			wantLen:   1,
+			wantKey:   "env",
+			wantValue: "production",
+			wantErr:   false,
+		},
+		{
+			name:    "multiple labels",
+			input:   []string{"env=production", "team=backend", "region=us-east-1"},
+			wantLen: 3,
+			wantErr: false,
+		},
+		{
+			name:      "value with equals sign",
+			input:     []string{"key=value=with=equals"},
+			wantLen:   1,
+			wantKey:   "key",
+			wantValue: "value=with=equals",
+			wantErr:   false,
+		},
+		{
+			name:    "missing value",
+			input:   []string{"keyonly"},
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			input:   []string{"=value"},
+			wantErr: true,
+		},
+		{
+			name:      "empty value is allowed",
+			input:     []string{"key="},
+			wantLen:   1,
+			wantKey:   "key",
+			wantValue: "",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels, err := parseLabels(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLabels() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(labels) != tt.wantLen {
+				t.Errorf("parseLabels() got %d labels, want %d", len(labels), tt.wantLen)
+				return
+			}
+			if tt.wantKey != "" {
+				got, ok := labels[tt.wantKey]
+				if !ok {
+					t.Errorf("parseLabels() missing key %q", tt.wantKey)
+				} else if got != tt.wantValue {
+					t.Errorf("parseLabels()[%q] = %q, want %q", tt.wantKey, got, tt.wantValue)
+				}
+			}
+		})
+	}
+}

--- a/cmd/guaccollect/cmd/oci.go
+++ b/cmd/guaccollect/cmd/oci.go
@@ -125,7 +125,11 @@ you have access to read and write to the respective blob store.`,
 			logger.Fatalf("unable to register oci collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue, labels)
 	},
 }
 
@@ -170,7 +174,11 @@ var ociRegistryCmd = &cobra.Command{
 			logger.Errorf("unable to register oci collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue, labels)
 	},
 }
 

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -41,6 +41,7 @@ func init() {
 		"publish-to-queue",
 		"gql-addr",
 		"enable-otel",
+		"label",
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)

--- a/cmd/guaccollect/cmd/s3.go
+++ b/cmd/guaccollect/cmd/s3.go
@@ -122,7 +122,11 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 			defer csubClient.Close()
 		}
 
-		initializeNATsandCollector(ctx, s3Opts.pubSubAddr, s3Opts.blobAddr, s3Opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, s3Opts.pubSubAddr, s3Opts.blobAddr, s3Opts.publishToQueue, labels)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -314,7 +314,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openvex/go-vex v0.2.7
 	github.com/ossf/scorecard/v5 v5.4.0
-	github.com/package-url/packageurl-go v0.1.3
+	github.com/package-url/packageurl-go v0.1.5
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/pitabwire/natspubsub v0.1.9
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1203,8 +1203,8 @@ github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE2
 github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=
 github.com/owenrumney/go-sarif/v3 v3.2.3 h1:n6mdX5ugKwCrZInvBsf6WumXmpAe3mbmQXgkXlIq34U=
 github.com/owenrumney/go-sarif/v3 v3.2.3/go.mod h1:1bV7t8SZg7pX41spaDkEUs8/yEjzk9JapztMoX1XNjg=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/assembler/backends/ent/migrate/Dockerfile
+++ b/pkg/assembler/backends/ent/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM arigaio/atlas:latest-alpine@sha256:fede7192bf84b860751dc115ff0b3805c45dde5eca172178028b56eff66c7d4b
+FROM arigaio/atlas:latest-alpine@sha256:2360d4db7bbd11e6edaff651b2d4e276299c717799b57cee07204b8cd2fceae7
 
 WORKDIR /app
 

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -215,8 +215,8 @@ func TestPurlConvert(t *testing.T) {
 				"arch": "core2-32",
 			}),
 		}, {
-			purlUri:  "pkg:cpan/Pod-Perldoc@3.20",
-			expected: pkg("cpan", "", "Pod-Perldoc", "3.20", "", map[string]string{}),
+			purlUri:  "pkg:cpan/MALLEN/Pod-Perldoc@3.20",
+			expected: pkg("cpan", "MALLEN", "Pod-Perldoc", "3.20", "", map[string]string{}),
 		}, {
 			purlUri:  "pkg:bitnami/apache@2.4.57",
 			expected: pkg("bitnami", "", "apache", "2.4.57", "", map[string]string{}),
@@ -323,7 +323,7 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 			}),
 		}, {
 			// The following are for docker PURLs
-			expectedPurlUri: "pkg:docker/dockerimage@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fcustomer",
+			expectedPurlUri: "pkg:docker/dockerimage@sha256:244fd47e07d10?repository_url=gcr.io%2Fcustomer",
 			input:           pkg("docker", "gcr.io/customer", "dockerimage", "sha256:244fd47e07d10", "", map[string]string{}),
 		}, {
 			expectedPurlUri: "pkg:docker/debian@dc437cc87d10?repository_url=smartentry",
@@ -336,13 +336,13 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 			input:           pkg("gem", "", "ruby-advisory-db-check", "0.12.4", "", map[string]string{}),
 		}, {
 			// TODO (Issue #635): url path escapes here? Will this be an issue when searching via purl in osv or deps.dev?
-			expectedPurlUri: "pkg:generic/openssl@1.1.10g?checksum=sha256%3Ade4d501267da&download_url=https%3A%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz",
+			expectedPurlUri: "pkg:generic/openssl@1.1.10g?checksum=sha256:de4d501267da&download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz",
 			input: pkg("generic", "", "openssl", "1.1.10g", "", map[string]string{
 				"download_url": "https://openssl.org/source/openssl-1.1.0g.tar.gz",
 				"checksum":     "sha256:de4d501267da",
 			}),
 		}, {
-			expectedPurlUri: "pkg:generic/bitwarderl?vcs_url=git%2Bhttps%3A%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
+			expectedPurlUri: "pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
 			input: pkg("generic", "", "bitwarderl", "", "", map[string]string{
 				"vcs_url": "git+https://git.fsfe.org/dxtr/bitwarderl@cc55108da32",
 			}),
@@ -356,7 +356,7 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 			expectedPurlUri: "pkg:hackage/3d-graphics-examples@0.0.0.2",
 			input:           pkg("hackage", "", "3d-graphics-examples", "0.0.0.2", "", map[string]string{}),
 		}, {
-			expectedPurlUri: "pkg:hex/bar@1.2.3?repository_url=https%3A%2F%2Fmyrepo.example.com",
+			expectedPurlUri: "pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com",
 			input: pkg("hex", "", "bar", "1.2.3", "", map[string]string{
 				"repository_url": "https://myrepo.example.com",
 			}),
@@ -373,7 +373,7 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 				"classifier": "dist",
 			}),
 		}, {
-			expectedPurlUri: "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https%3A%2F%2Fadb-5245952564735461.0.azuredatabricks.net%2Fapi%2F2.0%2Fmlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
+			expectedPurlUri: "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https:%2F%2Fadb-5245952564735461.0.azuredatabricks.net%2Fapi%2F2.0%2Fmlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
 			input: pkg("mlflow", "", "trafficsigns", "10", "", map[string]string{
 				"model_uuid":     "36233173b22f4c89b451f1228d700d49",
 				"run_id":         "410a3121-2709-4f88-98dd-dba0ef056b0a",
@@ -393,18 +393,18 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 			input:           pkg("qpkg", "blackberry", "com.qnx.sdp", "7.0.0.SGA201702151847", "", map[string]string{}),
 		}, {
 			// Special OCI case
-			expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?arch=amd64&repository_url=docker.io%2Flibrary&tag=latest",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&repository_url=docker.io%2Flibrary&tag=latest",
 			input: pkg("oci", "docker.io/library", "debian", "sha256:244fd47e07d10", "", map[string]string{
 				"arch": "amd64",
 				"tag":  "latest",
 			}),
 		}, {
-			expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
 			input: pkg("oci", "ghcr.io", "debian", "sha256:244fd47e07d10", "", map[string]string{
 				"tag": "bullseye",
 			}),
 		}, {
-			expectedPurlUri: "pkg:oci/hello-wasm@sha256%3A244fd47e07d10?tag=v1",
+			expectedPurlUri: "pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1",
 			input: pkg("oci", "", "hello-wasm", "sha256:244fd47e07d10", "", map[string]string{
 				"tag": "v1",
 			}),
@@ -526,7 +526,7 @@ func TestAllPkgTreeToPurl(t *testing.T) {
 			}),
 		}, {
 			// The following are for docker PURLs
-			expectedPurlUri: "pkg:docker/dockerimage@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fcustomer",
+			expectedPurlUri: "pkg:docker/dockerimage@sha256:244fd47e07d10?repository_url=gcr.io%2Fcustomer",
 			input:           allPkgTree("docker", "gcr.io/customer", "dockerimage", "sha256:244fd47e07d10", "", map[string]string{}),
 		}, {
 			expectedPurlUri: "pkg:docker/debian@dc437cc87d10?repository_url=smartentry",
@@ -539,13 +539,13 @@ func TestAllPkgTreeToPurl(t *testing.T) {
 			input:           allPkgTree("gem", "", "ruby-advisory-db-check", "0.12.4", "", map[string]string{}),
 		}, {
 			// TODO (Issue #635): url path escapes here? Will this be an issue when searching via purl in osv or deps.dev?
-			expectedPurlUri: "pkg:generic/openssl@1.1.10g?checksum=sha256%3Ade4d501267da&download_url=https%3A%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz",
+			expectedPurlUri: "pkg:generic/openssl@1.1.10g?checksum=sha256:de4d501267da&download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz",
 			input: allPkgTree("generic", "", "openssl", "1.1.10g", "", map[string]string{
 				"download_url": "https://openssl.org/source/openssl-1.1.0g.tar.gz",
 				"checksum":     "sha256:de4d501267da",
 			}),
 		}, {
-			expectedPurlUri: "pkg:generic/bitwarderl?vcs_url=git%2Bhttps%3A%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
+			expectedPurlUri: "pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
 			input: allPkgTree("generic", "", "bitwarderl", "", "", map[string]string{
 				"vcs_url": "git+https://git.fsfe.org/dxtr/bitwarderl@cc55108da32",
 			}),
@@ -559,7 +559,7 @@ func TestAllPkgTreeToPurl(t *testing.T) {
 			expectedPurlUri: "pkg:hackage/3d-graphics-examples@0.0.0.2",
 			input:           allPkgTree("hackage", "", "3d-graphics-examples", "0.0.0.2", "", map[string]string{}),
 		}, {
-			expectedPurlUri: "pkg:hex/bar@1.2.3?repository_url=https%3A%2F%2Fmyrepo.example.com",
+			expectedPurlUri: "pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com",
 			input: allPkgTree("hex", "", "bar", "1.2.3", "", map[string]string{
 				"repository_url": "https://myrepo.example.com",
 			}),
@@ -576,7 +576,7 @@ func TestAllPkgTreeToPurl(t *testing.T) {
 				"classifier": "dist",
 			}),
 		}, {
-			expectedPurlUri: "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https%3A%2F%2Fadb-5245952564735461.0.azuredatabricks.net%2Fapi%2F2.0%2Fmlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
+			expectedPurlUri: "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https:%2F%2Fadb-5245952564735461.0.azuredatabricks.net%2Fapi%2F2.0%2Fmlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
 			input: allPkgTree("mlflow", "", "trafficsigns", "10", "", map[string]string{
 				"model_uuid":     "36233173b22f4c89b451f1228d700d49",
 				"run_id":         "410a3121-2709-4f88-98dd-dba0ef056b0a",
@@ -596,18 +596,18 @@ func TestAllPkgTreeToPurl(t *testing.T) {
 			input:           allPkgTree("qpkg", "blackberry", "com.qnx.sdp", "7.0.0.SGA201702151847", "", map[string]string{}),
 		}, {
 			// Special OCI case
-			expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?arch=amd64&repository_url=docker.io%2Flibrary&tag=latest",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&repository_url=docker.io%2Flibrary&tag=latest",
 			input: allPkgTree("oci", "docker.io/library", "debian", "sha256:244fd47e07d10", "", map[string]string{
 				"arch": "amd64",
 				"tag":  "latest",
 			}),
 		}, {
-			expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
 			input: allPkgTree("oci", "ghcr.io", "debian", "sha256:244fd47e07d10", "", map[string]string{
 				"tag": "bullseye",
 			}),
 		}, {
-			expectedPurlUri: "pkg:oci/hello-wasm@sha256%3A244fd47e07d10?tag=v1",
+			expectedPurlUri: "pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1",
 			input: allPkgTree("oci", "", "hello-wasm", "sha256:244fd47e07d10", "", map[string]string{
 				"tag": "v1",
 			}),
@@ -736,7 +736,7 @@ func TestPkgToPurl(t *testing.T) {
 			qualifiers:      []string{"arch", "amd64", "distro", "stretch"},
 		}, {
 			// The following are for docker PURLs
-			expectedPurlUri: "pkg:docker/dockerimage@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fcustomer",
+			expectedPurlUri: "pkg:docker/dockerimage@sha256:244fd47e07d10?repository_url=gcr.io%2Fcustomer",
 			pkgType:         "docker",
 			namespace:       "gcr.io/customer",
 			name:            "dockerimage",
@@ -768,7 +768,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{},
 		}, {
-			expectedPurlUri: "pkg:generic/openssl@1.1.10g?checksum=sha256%3Ade4d501267da&download_url=https%3A%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz",
+			expectedPurlUri: "pkg:generic/openssl@1.1.10g?checksum=sha256:de4d501267da&download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz",
 			pkgType:         "generic",
 			namespace:       "",
 			name:            "openssl",
@@ -776,7 +776,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{"download_url", "https://openssl.org/source/openssl-1.1.0g.tar.gz", "checksum", "sha256:de4d501267da"},
 		}, {
-			expectedPurlUri: "pkg:generic/bitwarderl?vcs_url=git%2Bhttps%3A%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
+			expectedPurlUri: "pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
 			pkgType:         "generic",
 			namespace:       "",
 			name:            "bitwarderl",
@@ -808,7 +808,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{},
 		}, {
-			expectedPurlUri: "pkg:hex/bar@1.2.3?repository_url=https%3A%2F%2Fmyrepo.example.com",
+			expectedPurlUri: "pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com",
 			pkgType:         "hex",
 			namespace:       "",
 			name:            "bar",
@@ -840,7 +840,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{"type", "zip", "classifier", "dist"},
 		}, {
-			expectedPurlUri: "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https%3A%2F%2Fadb-5245952564735461.0.azuredatabricks.net%2Fapi%2F2.0%2Fmlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
+			expectedPurlUri: "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https:%2F%2Fadb-5245952564735461.0.azuredatabricks.net%2Fapi%2F2.0%2Fmlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
 			pkgType:         "mlflow",
 			namespace:       "",
 			name:            "trafficsigns",
@@ -881,7 +881,7 @@ func TestPkgToPurl(t *testing.T) {
 			qualifiers:      []string{},
 		}, {
 			// Special OCI case
-			expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?arch=amd64&repository_url=docker.io%2Flibrary&tag=latest",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&repository_url=docker.io%2Flibrary&tag=latest",
 			pkgType:         "oci",
 			namespace:       "docker.io/library",
 			name:            "debian",
@@ -889,7 +889,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{"arch", "amd64", "tag", "latest"},
 		}, {
-			expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
 			pkgType:         "oci",
 			namespace:       "ghcr.io",
 			name:            "debian",
@@ -897,7 +897,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{"tag", "bullseye"},
 		}, {
-			expectedPurlUri: "pkg:oci/hello-wasm@sha256%3A244fd47e07d10?tag=v1",
+			expectedPurlUri: "pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1",
 			pkgType:         "oci",
 			namespace:       "",
 			name:            "hello-wasm",

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -143,6 +143,8 @@ func init() {
 
 	set.String("header-file", "", "a text file containing HTTP headers to send to the GQL server, in RFC 822 format")
 
+	set.StringSlice("label", []string{}, "label to attach to collected documents as HasMetadata, in key=value format (can be specified multiple times)")
+
 	set.String("kubescape-namespace", "kubescape", "Kubernetes namespace to get/watch sboms from.")
 	set.Bool("kubescape-filtered", false, "If false: get/watch \"sbomsyfts\", if true: get/watch \"sbomsyftfiltereds\"")
 

--- a/pkg/guacrest/server/retrieveDependencies_test.go
+++ b/pkg/guacrest/server/retrieveDependencies_test.go
@@ -183,16 +183,16 @@ func Test_RetrieveDependencies_ByPurl(t *testing.T) {
 			name: "Endpoint works for OCI purl",
 			data: GuacData{
 				Packages: []string{
-					"pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
-					"pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless&tag=latest",
+					"pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
+					"pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io%2Fdistroless&tag=latest",
 				},
 				HasSboms: []HasSbom{{
-					Subject:          "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
-					IncludedSoftware: []string{"pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless&tag=latest"},
+					Subject:          "pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
+					IncludedSoftware: []string{"pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io%2Fdistroless&tag=latest"},
 				}},
 			},
-			purl:           "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
-			expectedByName: []string{"pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless&tag=latest"},
+			purl:           "pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io&tag=bullseye",
+			expectedByName: []string{"pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io%2Fdistroless&tag=latest"},
 		},
 		{
 			name: "Non-canonical purl may not round trip",

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -39,6 +39,7 @@ type Document struct {
 	Encoding          EncodingType
 	SourceInformation SourceInformation
 	ChildLogger       *zap.SugaredLogger
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // DocumentTree describes the output of a document tree that resulted from

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -37,13 +37,14 @@ func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []TrustInf
 }
 
 // CreateAssemblerInput creates the GuacNodes and GuacEdges that are needed by the assembler
-func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []TrustInformation, srcInfo processor.SourceInformation) *assembler.AssemblerInput {
+func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []TrustInformation, srcInfo processor.SourceInformation, labels map[string]string) *assembler.AssemblerInput {
 	predicates := b.docParser.GetPredicates(ctx)
 
 	if predicates == nil {
 		predicates = &assembler.IngestPredicates{}
 	}
 	AddMetadata(predicates, foundIdentities, srcInfo)
+	AddLabels(predicates, srcInfo, labels)
 
 	return predicates
 }

--- a/pkg/ingestor/parser/common/graph_builder_test.go
+++ b/pkg/ingestor/parser/common/graph_builder_test.go
@@ -1,0 +1,163 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/guacsec/guac/pkg/assembler"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+func TestAddLabels_GeneratesHasMetadata(t *testing.T) {
+	testPkg := &model.PkgInputSpec{
+		Type:      "npm",
+		Namespace: strPtr(""),
+		Name:      "express",
+		Version:   strPtr("4.18.2"),
+	}
+	testArtifact := &model.ArtifactInputSpec{
+		Algorithm: "sha256",
+		Digest:    "abc123",
+	}
+
+	tests := []struct {
+		name            string
+		predicates      *assembler.IngestPredicates
+		labels          map[string]string
+		wantHMCount     int
+		wantFirstKey    string
+		wantFirstValue  string
+		wantHasPkg      bool
+		wantHasArtifact bool
+	}{
+		{
+			name: "no labels produces no HasMetadata",
+			predicates: &assembler.IngestPredicates{
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: testPkg, HasSBOM: &model.HasSBOMInputSpec{}},
+				},
+			},
+			labels:      nil,
+			wantHMCount: 0,
+		},
+		{
+			name: "labels on package SBOM",
+			predicates: &assembler.IngestPredicates{
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: testPkg, HasSBOM: &model.HasSBOMInputSpec{}},
+				},
+			},
+			labels:         map[string]string{"env": "staging", "team": "backend"},
+			wantHMCount:    2,
+			wantFirstKey:   "env",
+			wantFirstValue: "staging",
+			wantHasPkg:     true,
+		},
+		{
+			name: "labels on artifact SBOM",
+			predicates: &assembler.IngestPredicates{
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Artifact: testArtifact, HasSBOM: &model.HasSBOMInputSpec{}},
+				},
+			},
+			labels:          map[string]string{"env": "prod"},
+			wantHMCount:     1,
+			wantFirstKey:    "env",
+			wantFirstValue:  "prod",
+			wantHasArtifact: true,
+		},
+		{
+			name: "labels on SBOM with both pkg and artifact",
+			predicates: &assembler.IngestPredicates{
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: testPkg, Artifact: testArtifact, HasSBOM: &model.HasSBOMInputSpec{}},
+				},
+			},
+			labels:      map[string]string{"team": "platform"},
+			wantHMCount: 2, // one for pkg, one for artifact
+		},
+		{
+			name: "no HasSBOM means no HasMetadata even with labels",
+			predicates: &assembler.IngestPredicates{
+				IsDependency: []assembler.IsDependencyIngest{
+					{Pkg: testPkg, IsDependency: &model.IsDependencyInputSpec{}},
+				},
+			},
+			labels:      map[string]string{"env": "production"},
+			wantHMCount: 0,
+		},
+		{
+			name: "multiple SBOMs multiply labels",
+			predicates: &assembler.IngestPredicates{
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: testPkg, HasSBOM: &model.HasSBOMInputSpec{}},
+					{Artifact: testArtifact, HasSBOM: &model.HasSBOMInputSpec{}},
+				},
+			},
+			labels:      map[string]string{"env": "prod"},
+			wantHMCount: 2, // one per SBOM subject
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srcInfo := processor.SourceInformation{
+				Collector:   "TestCollector",
+				Source:      "test://source",
+				DocumentRef: "sha256_test",
+			}
+
+			AddLabels(tt.predicates, srcInfo, tt.labels)
+
+			if len(tt.predicates.HasMetadata) != tt.wantHMCount {
+				t.Errorf("got %d HasMetadata, want %d", len(tt.predicates.HasMetadata), tt.wantHMCount)
+				return
+			}
+
+			if tt.wantHMCount == 0 {
+				return
+			}
+
+			first := tt.predicates.HasMetadata[0]
+			if tt.wantFirstKey != "" && first.HasMetadata.Key != tt.wantFirstKey {
+				t.Errorf("first HasMetadata key = %q, want %q", first.HasMetadata.Key, tt.wantFirstKey)
+			}
+			if tt.wantFirstValue != "" && first.HasMetadata.Value != tt.wantFirstValue {
+				t.Errorf("first HasMetadata value = %q, want %q", first.HasMetadata.Value, tt.wantFirstValue)
+			}
+			if tt.wantHasPkg && first.Pkg == nil {
+				t.Error("expected first HasMetadata to have Pkg, got nil")
+			}
+			if tt.wantHasArtifact && first.Artifact == nil {
+				t.Error("expected first HasMetadata to have Artifact, got nil")
+			}
+
+			// Verify collector metadata is set
+			if first.HasMetadata.Collector != "TestCollector" {
+				t.Errorf("HasMetadata.Collector = %q, want %q", first.HasMetadata.Collector, "TestCollector")
+			}
+			if first.HasMetadata.Origin != "test://source" {
+				t.Errorf("HasMetadata.Origin = %q, want %q", first.HasMetadata.Origin, "test://source")
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/pkg/ingestor/parser/common/labels.go
+++ b/pkg/ingestor/parser/common/labels.go
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"sort"
+	"time"
+
+	"github.com/guacsec/guac/pkg/assembler"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+// AddLabels generates HasMetadata predicates from user-provided labels.
+// Labels are attached to the package or artifact subjects of any HasSBOM predicates.
+func AddLabels(predicates *assembler.IngestPredicates, srcInfo processor.SourceInformation, labels map[string]string) {
+	if len(labels) == 0 {
+		return
+	}
+
+	now := time.Now()
+
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, sbom := range predicates.HasSBOM {
+		for _, key := range keys {
+			hm := &model.HasMetadataInputSpec{
+				Key:           key,
+				Value:         labels[key],
+				Justification: "Added by guaccollect --label flag",
+				Timestamp:     now,
+				Collector:     srcInfo.Collector,
+				Origin:        srcInfo.Source,
+				DocumentRef:   srcInfo.DocumentRef,
+			}
+			if sbom.Pkg != nil {
+				predicates.HasMetadata = append(predicates.HasMetadata, assembler.HasMetadataIngest{
+					Pkg:          sbom.Pkg,
+					PkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+					HasMetadata:  hm,
+				})
+			}
+			if sbom.Artifact != nil {
+				predicates.HasMetadata = append(predicates.HasMetadata, assembler.HasMetadataIngest{
+					Artifact:    sbom.Artifact,
+					HasMetadata: hm,
+				})
+			}
+		}
+	}
+}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -96,7 +96,7 @@ func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree, scan
 	}
 
 	for _, builder := range docTreeBuilder.graphBuilders {
-		assemblerInput := builder.CreateAssemblerInput(ctx, docTreeBuilder.identities, docTree.Document.SourceInformation)
+		assemblerInput := builder.CreateAssemblerInput(ctx, docTreeBuilder.identities, docTree.Document.SourceInformation, docTree.Document.Labels)
 		assemblerInputs = append(assemblerInputs, *assemblerInput)
 		if idStrings, err := builder.GetIdentifiers(ctx); err == nil {
 			identifierStrings = append(identifierStrings, idStrings)


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds label support to `guaccollect` so you can tag collected documents and store them as `HasMetadata` on SBOM subjects. Also updates `github.com/package-url/packageurl-go` to v0.1.5 (PURL encoding fixes) and bumps `arigaio/atlas`.

- **New Features**
  - `guaccollect`: new `--label key=value` flag on `files`, `gcs`, `github`, `kubescape`, `s3`, and `oci`; pass multiple to attach labels.
  - Labels propagate with each document and are recorded as `HasMetadata` on package or artifact SBOM subjects (with collector, origin, and timestamp).

<sup>Written for commit e17047a4d4950843aa5c3d5006b1207915e229e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

